### PR TITLE
#166732850: admin can delete car 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+#### What does this PR do?
+#### Description of Task to be completed?
+#### How should this be manually tested?
+#### Any background context you want to provide?
+#### What are the relevant pivotal tracker stories?
+#### Screenshots (if appropriate)
+#### Questions:

--- a/server/controllers/admindelete.js
+++ b/server/controllers/admindelete.js
@@ -1,6 +1,19 @@
-import cars from '../models/car';
+import pool from '../helpers/db/pool';
+import deleteValidation from '../helpers/admindelete';
 
-const adminDelete = (req, res) => {
+
+
+
+const adminDelete = async (req, res) => {
+
+    const { error } = deleteValidation.validation(req.params);
+
+    if( error ) {
+        return res.status(400).json({
+            status:400,
+            error: error.details[0].message.split('"').join(' ')
+        })
+    }
 
     if(req.user.is_admin === false){
         return res.status(403).json({
@@ -11,15 +24,23 @@ const adminDelete = (req, res) => {
 
     const checkId = parseInt(req.params.id,10);
 
-    const checkCar = cars.findIndex(car => car.id === checkId);
 
-    if(checkCar){
-        cars.splice(checkCar,1);
-        return res.status(200).json({
-            status:200,
-            message:"Car advert succesful deleted"
+    const checkCar = await pool.query("SELECT * from cars WHERE id = $1",[checkId]);
+
+    if(!checkCar.rows.length){
+        return res.status(404).json({
+            status:404,
+            message:"Car not found"
         });
     }
+
+    const checkDel = await pool.query("DELETE from cars WHERE id = $1",[checkId]);
+
+
+    return res.status(200).json({
+        status:200,
+        message:"Car deleted successfully"
+    });
 
 }
 

--- a/server/helpers/admindelete.js
+++ b/server/helpers/admindelete.js
@@ -1,0 +1,15 @@
+import Joi from 'joi';
+
+
+const deleteCar = {
+        validation(carId){
+          const deleteValidateion = {
+            id: Joi.number().integer().max(9999).min(0)
+          };
+
+        return Joi.validate(carId,deleteValidateion);
+    },
+};
+
+
+export default deleteCar;


### PR DESCRIPTION
#### What does this PR do?
         Allows Adminto delete all the car
#### Description of Task to be completed?

- create endpoint to delete car

#### How should this be manually tested? 

- clone this repo ` git clone https://github.com/crispy1996/Andela_AutoMart.git`

- checkout the branch `#166732850: admin can delete car`

- run `npm start` 

- Using [postman]

- Navigate to `POST /api/v1/car/`  then  create a car adverts
  {    "state":"new",
	"price":800,
	"manufacturer": "Toyota",
	"model": "2 doors",
	"bodyType": Van"  }

- Copy the id of the car

- Navidate to `DELETE /api/v1/car/:id` to delete a car advert

#### What are the relevant pivotal tracker stories?
        #166732850
#### Screenshots (if appropriate)
![delete](https://user-images.githubusercontent.com/39420985/59759512-883a9f80-9290-11e9-8e34-0a253da0733f.JPG)

